### PR TITLE
Fix bug when manual ploidy boundaries fall outside strict ploidy boudaries

### DIFF
--- a/ASCAT/R/ascat.R
+++ b/ASCAT/R/ascat.R
@@ -1055,7 +1055,7 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
     }
     
     # if no solution, drop the percentzero > MINPERCZERO filter (allow non-aberrant solutions - but limit the ploidy options)
-    if (nropt == 0) {
+    if (nropt == 0 & MINPLOIDY < MAXPLOIDYSTRICT & MAXPLOIDY > MINPLOIDYSTRICT) {
       for (i in 4:(dim(d)[1]-3)) {
         for (j in 4:(dim(d)[2]-3)) {
           m = d[i,j]
@@ -1128,7 +1128,7 @@ runASCAT = function(lrr, baf, lrrsegmented, bafsegmented, gender, SNPpos, chromo
     }
     
     # if still no solution, drop the percentzero > MINPERCENTZERO filter, but strict ploidy borders
-    if (nropt == 0) {
+    if (nropt == 0 & MINPLOIDY < MAXPLOIDYSTRICT & MAXPLOIDY > MINPLOIDYSTRICT) {
       for (i in 4:(dim(d)[1]-3)) {
         for (j in 4:(dim(d)[2]-3)) {
           m = d[i,j]

--- a/ASCAT/R/ascat.R
+++ b/ASCAT/R/ascat.R
@@ -324,7 +324,7 @@ ascat.GCcorrect = function(ASCATobj, GCcontentfile = NULL) {
 #' 1. Tumor_LogR data matrix\cr
 #' 2. Tumor_BAF data matrix\cr
 #' 3. Tumor_LogR_segmented: matrix of LogR segmented values\cr
-#' 4. Tumor_BAF_segmented: list of BAF segmented values; each element in the list is a matrix containing the segmented values for one sample (only for probes that are germline homozygous)\cr
+#' 4. Tumor_BAF_segmented: list of BAF segmented values; each element in the list is a matrix containing the segmented values for one sample (only for probes that are not germline homozygous)\cr
 #' 5. Germline_LogR data matrix\cr
 #' 6. Germline_BAF data matrix\cr
 #' 7. SNPpos: position of all SNPs\cr
@@ -1760,6 +1760,7 @@ fastAspcf <- function(logR, allB, kmin, gamma){
   
   nseg = 0
   var2 = 0
+  var3 = 0
   breakpts = 0
   larger = TRUE
   repeat{
@@ -1772,6 +1773,7 @@ fastAspcf <- function(logR, allB, kmin, gamma){
     
     sd1 <- getMad(logRpart)
     sd2 <- getMad(allBflip)
+    sd3 <- getMad(allBpart) 
     
     #Must check that sd1 and sd2 are defined and != 0:
     sd.valid <- c(!is.na(sd1),!is.na(sd2),sd1!=0,sd2!=0)
@@ -1784,6 +1786,7 @@ fastAspcf <- function(logR, allB, kmin, gamma){
       larger = breakptspart>breakpts[length(breakpts)]
       breakpts <- c(breakpts, breakptspart[larger])
       var2 <- var2 + sd2^2
+      var3 <- var3 + sd3^2
       nseg = nseg+1
     }
     
@@ -1798,6 +1801,7 @@ fastAspcf <- function(logR, allB, kmin, gamma){
   breakpts <- unique(c(breakpts, N))
   if(nseg==0){nseg=1}  #just in case the sd-test never passes.
   sd2 <- sqrt(var2/nseg)
+  sd3 <- sqrt(var3/nseg)
   
   # On each segment calculate mean of unflipped B allele data
   frst <- breakpts[1:length(breakpts)-1] + 1
@@ -1806,7 +1810,7 @@ fastAspcf <- function(logR, allB, kmin, gamma){
   
   yhat1 <- rep(NA,N)
   yhat2 <- rep(NA,N)
-  
+
   for(i in 1:nseg){
     yhat1[frst[i]:last[i]] <- rep(mean(logR[frst[i]:last[i]]), last[i]-frst[i]+1)
     yi2 <- allB[frst[i]:last[i]]
@@ -1820,7 +1824,8 @@ fastAspcf <- function(logR, allB, kmin, gamma){
     # Make a (slightly arbitrary) decision concerning branches
     # This may be improved by a test of equal variances
     if(sqrt(sd2^2+mu^2) < 2*sd2){
-      mu <- 0
+    # if(sd3 < 1.8*sd2){
+       mu <- 0
     }
     yhat2[frst[i]:last[i]] <- rep(mu+0.5,last[i]-frst[i]+1)
   }


### PR DESCRIPTION
Ignore strict ploidy solutions when manual min_ploidy and max_ploidy boundaries fall outside builtin strict ploidy boundaries